### PR TITLE
feat: Add PI constant as global shorthand for Math.PI

### DIFF
--- a/src/hydra-synth.js
+++ b/src/hydra-synth.js
@@ -56,6 +56,7 @@ class HydraRenderer {
         fps: 0
       },
       speed: 1,
+      PI: Math.PI,
       mouse: Mouse,
       render: this._render.bind(this),
       setResolution: this.setResolution.bind(this),


### PR DESCRIPTION
This PR adds a PI constant as a global shorthand for Math.PI in Hydra-Synth.

## Changes
- Added `PI: Math.PI` to the synth object in `src/hydra-synth.js`
- PI is now available globally when `makeGlobal` is enabled (default)

## Usage
Users can now use `PI` instead of `Math.PI` in their code:
```javascript
osc(10, 0.1, PI/4).out() // Instead of Math.PI/4
shape(4, 0.1).rotate(PI/2).out() // Instead of Math.PI/2
```

Closes #3

🤖 Generated with [Claude Code](https://claude.ai/code)